### PR TITLE
[INTEG-56, INTEG-184] Update API documentation with donation endpoints

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1832,12 +1832,12 @@ uri = URI.parse('https://app.tatango.com/api/v2/lists/ID/subscribers/SUBSCRIBER_
 http = Net::HTTP.new(uri.host, uri.port)
 request = Net:HTTP::Post.new(uri.request_url)
 request.basic_auth("emailaddress@mydomain.com", "my_api_key")
-request.body({"donation":{"amount":"5","donated_at":"2016-09-07T14:10:53-07:00","donation_platform":"AMCE Donations","utm_campaign":"campaign", "utm_medium":"medium","utm_source":"source", "utm_term":"term","utm_content":"content", "refcodes_attributes":[{"refcode":"refcode1"},{"refcode":"refcode2"}]}});
+request.body({"amount":"5","donated_at":"2016-09-07T14:10:53-07:00","donation_platform":"AMCE Donations","utm_campaign":"campaign", "utm_medium":"medium","utm_source":"source", "utm_term":"term","utm_content":"content", "refcodes":["refcode1", "refcode2"]});
 response = http.request(request)
 ```
 
 ```shell
-curl "https://app.tatango.com/api/v2/lists/ID/subscribers/SUBSCRIBER_ID/donations" -d '{"donation":{"amount":"5","donated_at":"2016-09-07T14:10:53-07:00","donation_platform":"AMCE Donations","utm_campaign":"campaign", "utm_medium":"medium","utm_source":"source", "utm_term":"term","utm_content":"content", "refcodes_attributes":[{"refcode":"refcode1"},{"refcode":"refcode2"}]}}' -X POST \
+curl "https://app.tatango.com/api/v2/lists/ID/subscribers/SUBSCRIBER_ID/donations" -d '{"amount":"5","donated_at":"2016-09-07T14:10:53-07:00","donation_platform":"AMCE Donations","utm_campaign":"campaign", "utm_medium":"medium","utm_source":"source", "utm_term":"term","utm_content":"content", "refcodes":["refcode1", "refcode2"]}' -X POST \
 	-H "Accept: application/json" \
 	-H "Content-Type: application/json" \
 	-u emailaddress@mydomain.com:my_api_key \
@@ -1849,7 +1849,7 @@ curl "https://app.tatango.com/api/v2/lists/ID/subscribers/SUBSCRIBER_ID/donation
 var request = new XMLHttpRequest();
 request.open("POST", "https://app.tatango.com/api/v2/lists/ID/subscribers/SUBSCRIBER_ID/donations", false);
 request.setRequestHeader("Authorization", "Basic " + btoa("emailaddress@mydomain.com:my_api_key"));
-var data = JSON.stringify({"donation":{"amount":"5","donated_at":"2016-09-07T14:10:53-07:00","donation_platform":"AMCE Donations","utm_campaign":"campaign", "utm_medium":"medium","utm_source":"source", "utm_term":"term","utm_content":"content", "refcodes_attributes":[{"refcode":"refcode1"},{"refcode":"refcode2"}]}});
+var data = JSON.stringify({"amount":"5","donated_at":"2016-09-07T14:10:53-07:00","donation_platform":"AMCE Donations","utm_campaign":"campaign", "utm_medium":"medium","utm_source":"source", "utm_term":"term","utm_content":"content", "refcodes":["refcode1", "refcode2"]});
 request.send(data);
 ```
 
@@ -1903,7 +1903,7 @@ donation[utm_medium] | (optional) The utm_medium URL parameter of the link used 
 donation[utm_source] | (optional) The utm_source URL parameter of the link used to make the donation - char(191)
 donation[utm_term] | (optional) The utm_term URL parameter of the link used to make the donation - char(191)
 donation[utm_content] | (optional) The utm_content URL parameter of the link used to make the donation - char(191)
-donation[refcodes_attributes] | (optional) List of refcode URL parameters of the link used to make the donation. For example: [{"refcode": "refcode1"}, {"refcode": "refcode2"}]
+donation[refcodes] | (optional) Array of refcode URL parameters of the link used to make the donation. For example: ["refcode1", "refcode2"]
 
 ### Responses Explained
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1703,11 +1703,12 @@ request.send(null);
        "utm_source": "source",
        "utm_term": "term",
        "utm_content": "content",
-       "phone_number":"2141234567",
+       "donation_platform_uid": "foo",
        "refcodes":[
         "refcode1",
         "refcode2"
-       ]
+       ],
+      "phone_number":"2141234567"
    }
 }
 ```
@@ -1731,7 +1732,8 @@ Key | Description
 id | The ID of the donation.
 amount | The amount of money (in USD) that the subscriber donated.
 donated_at | The date and time that the donation was made.
-donated_platform | The donation platform that the donation was made using.
+donation_platform | The donation platform that the donation was made using.
+donation_platform_uid | The unique id associated to the donation.
 utm_campaign | The utm_campaign URL parameter of the link used to make the donation.
 utm_medium | The utm_medium URL parameter of the link used to make the donation.
 utm_source | The utm_source URL parameter of the link used to make the donation.
@@ -1784,11 +1786,12 @@ request.send(null);
        "utm_source": "source",
        "utm_term": "term",
        "utm_content": "content",
-       "phone_number":"2141234567",
+       "donation_platform_uid": "foo",
        "refcodes":[
         "refcode1",
         "refcode2"
-       ]
+       ],
+      "phone_number":"2141234567"
    }
 }
 ```
@@ -1813,7 +1816,8 @@ Key | Description
 id | The ID of the donation.
 amount | The amount of money (in USD) that the subscriber donated.
 donated_at | The date and time that the donation was made.
-donated_platform | The donation platform that the donation was made using.
+donation_platform | The donation platform that the donation was made using.
+donation_platform_uid | The unique id associated to the donation.
 utm_campaign | The utm_campaign URL parameter of the link used to make the donation.
 utm_medium | The utm_medium URL parameter of the link used to make the donation.
 utm_source | The utm_source URL parameter of the link used to make the donation.
@@ -1832,12 +1836,12 @@ uri = URI.parse('https://app.tatango.com/api/v2/lists/ID/subscribers/SUBSCRIBER_
 http = Net::HTTP.new(uri.host, uri.port)
 request = Net:HTTP::Post.new(uri.request_url)
 request.basic_auth("emailaddress@mydomain.com", "my_api_key")
-request.body({"amount":"5","donated_at":"2016-09-07T14:10:53-07:00","donation_platform":"AMCE Donations","utm_campaign":"campaign", "utm_medium":"medium","utm_source":"source", "utm_term":"term","utm_content":"content", "refcodes":["refcode1", "refcode2"]});
+request.body({"amount":"5","donated_at":"2016-09-07T14:10:53-07:00","donation_platform":"AMCE Donations","donation_platform_uid":"foo","utm_campaign":"campaign", "utm_medium":"medium","utm_source":"source", "utm_term":"term","utm_content":"content", "refcodes":["refcode1", "refcode2"]});
 response = http.request(request)
 ```
 
 ```shell
-curl "https://app.tatango.com/api/v2/lists/ID/subscribers/SUBSCRIBER_ID/donations" -d '{"amount":"5","donated_at":"2016-09-07T14:10:53-07:00","donation_platform":"AMCE Donations","utm_campaign":"campaign", "utm_medium":"medium","utm_source":"source", "utm_term":"term","utm_content":"content", "refcodes":["refcode1", "refcode2"]}' -X POST \
+curl "https://app.tatango.com/api/v2/lists/ID/subscribers/SUBSCRIBER_ID/donations" -d '{"amount":"5","donated_at":"2016-09-07T14:10:53-07:00","donation_platform":"AMCE Donations","donation_platform_uid":"foo","utm_campaign":"campaign","utm_medium":"medium","utm_source":"source", "utm_term":"term","utm_content":"content", "refcodes":["refcode1", "refcode2"]}' -X POST \
 	-H "Accept: application/json" \
 	-H "Content-Type: application/json" \
 	-u emailaddress@mydomain.com:my_api_key \
@@ -1849,7 +1853,7 @@ curl "https://app.tatango.com/api/v2/lists/ID/subscribers/SUBSCRIBER_ID/donation
 var request = new XMLHttpRequest();
 request.open("POST", "https://app.tatango.com/api/v2/lists/ID/subscribers/SUBSCRIBER_ID/donations", false);
 request.setRequestHeader("Authorization", "Basic " + btoa("emailaddress@mydomain.com:my_api_key"));
-var data = JSON.stringify({"amount":"5","donated_at":"2016-09-07T14:10:53-07:00","donation_platform":"AMCE Donations","utm_campaign":"campaign", "utm_medium":"medium","utm_source":"source", "utm_term":"term","utm_content":"content", "refcodes":["refcode1", "refcode2"]});
+var data = JSON.stringify({"amount":"5","donated_at":"2016-09-07T14:10:53-07:00","donation_platform":"AMCE Donations","donation_platform_uid":"foo","utm_campaign":"campaign","utm_medium":"medium","utm_source":"source", "utm_term":"term","utm_content":"content", "refcodes":["refcode1", "refcode2"]});
 request.send(data);
 ```
 
@@ -1868,7 +1872,8 @@ request.send(data);
       "utm_source": "source",
       "utm_term": "term",
       "utm_content": "content",
-      "phone_number":"2141234567",
+      "donation_platform_uid": "foo",
+      "phone_number": "2141234567",
       "refcodes":[
         "refcode1",
         "refcode2"
@@ -1896,6 +1901,7 @@ SUBSCRIBER_ID | ID of the subscriber (phone number)
 Parameter | Description
 --------- | -----------
 amount | The amount of money (in USD) that the subscriber donated - decimal(8,2)
+donation_platform_uid | A unique id for the donation - char(191)
 donated_at | (optional) The date and time that the donation was made - datetime
 donation_platform | (optional) The donation platform that the donation was made using - char(191)
 utm_campaign | (optional) The utm_campaign URL parameter of the link used to make the donation - char(191)
@@ -1913,6 +1919,7 @@ id | The ID of the donation.
 amount | The amount of money (in USD) that the subscriber donated.
 donated_at | The date and time that the donation was made.
 donated_platform | The donation platform that the donation was made using.
+donation_platform_uid | The unique id associated to the donation.
 utm_campaign | The utm_campaign URL parameter of the link used to make the donation.
 utm_medium | The utm_medium URL parameter of the link used to make the donation.
 utm_source | The utm_source URL parameter of the link used to make the donation.
@@ -1931,12 +1938,12 @@ uri = URI.parse('https://app.tatango.com/api/v2/lists/ID/messages/MESSAGE_ID/don
 http = Net::HTTP.new(uri.host, uri.port)
 request = Net:HTTP::Post.new(uri.request_url)
 request.basic_auth("emailaddress@mydomain.com", "my_api_key")
-request.body({"amount":"5","donated_at":"2016-09-07T14:10:53-07:00","donation_platform":"AMCE Donations","utm_campaign":"campaign", "utm_medium":"medium","utm_source":"source", "utm_term":"term","utm_content":"content", "refcodes":["refcode1", "refcode2"]});
+request.body({"amount":"5","donated_at":"2016-09-07T14:10:53-07:00","donation_platform":"AMCE Donations","donation_platform_uid":"foo","utm_campaign":"campaign", "utm_medium":"medium","utm_source":"source", "utm_term":"term","utm_content":"content", "refcodes":["refcode1", "refcode2"]});
 response = http.request(request)
 ```
 
 ```shell
-curl "https://app.tatango.com/api/v2/lists/ID/messages/MESSAGE_ID/donations" -d '{"amount":"5","donated_at":"2016-09-07T14:10:53-07:00","donation_platform":"AMCE Donations","utm_campaign":"campaign", "utm_medium":"medium","utm_source":"source", "utm_term":"term","utm_content":"content", "refcodes":["refcode1", "refcode2"]}' -X POST \
+curl "https://app.tatango.com/api/v2/lists/ID/messages/MESSAGE_ID/donations" -d '{"amount":"5","donated_at":"2016-09-07T14:10:53-07:00","donation_platform":"AMCE Donations","donation_platform_uid":"foo","utm_campaign":"campaign","utm_medium":"medium","utm_source":"source", "utm_term":"term","utm_content":"content", "refcodes":["refcode1", "refcode2"]}' -X POST \
 	-H "Accept: application/json" \
 	-H "Content-Type: application/json" \
 	-u emailaddress@mydomain.com:my_api_key \
@@ -1948,7 +1955,7 @@ curl "https://app.tatango.com/api/v2/lists/ID/messages/MESSAGE_ID/donations" -d 
 var request = new XMLHttpRequest();
 request.open("POST", "https://app.tatango.com/api/v2/lists/ID/messages/MESSAGE_ID/donations", false);
 request.setRequestHeader("Authorization", "Basic " + btoa("emailaddress@mydomain.com:my_api_key"));
-var data = JSON.stringify({"amount":"5","donated_at":"2016-09-07T14:10:53-07:00","donation_platform":"AMCE Donations","utm_campaign":"campaign", "utm_medium":"medium","utm_source":"source", "utm_term":"term","utm_content":"content", "refcodes":["refcode1", "refcode2"]});
+var data = JSON.stringify({"amount":"5","donated_at":"2016-09-07T14:10:53-07:00","donation_platform":"AMCE Donations","donation_platform_uid":"foo","utm_campaign":"campaign","utm_medium":"medium","utm_source":"source", "utm_term":"term","utm_content":"content", "refcodes":["refcode1", "refcode2"]});
 request.send(data);
 ```
 
@@ -1967,6 +1974,7 @@ request.send(data);
       "utm_source": "source",
       "utm_term": "term",
       "utm_content": "content",
+      "donation_platform_uid": "foo",
       "refcodes":[
         "refcode1",
         "refcode2"
@@ -1990,9 +1998,11 @@ MESSAGE_ID | ID of the message
 
 
 ### JSON Parameters (JSON Object)
+
 Parameter | Description
 --------- | -----------
-amount | The amount of money (in USD) that was donated - decimal(8,2)
+amount | The amount of money (in USD) that the subscriber donated - decimal(8,2)
+donation_platform_uid | A unique id for the donation - char(191)
 donated_at | (optional) The date and time that the donation was made - datetime
 donation_platform | (optional) The donation platform that the donation was made using - char(191)
 utm_campaign | (optional) The utm_campaign URL parameter of the link used to make the donation - char(191)
@@ -2007,14 +2017,16 @@ refcodes | (optional) Array of refcode URL parameters of the link used to make t
 Key | Description
 --------- | -----------
 id | The ID of the donation.
-amount | The amount of money (in USD) that was donated.
+amount | The amount of money (in USD) that the subscriber donated.
 donated_at | The date and time that the donation was made.
 donated_platform | The donation platform that the donation was made using.
+donation_platform_uid | The unique id associated to the donation.
 utm_campaign | The utm_campaign URL parameter of the link used to make the donation.
 utm_medium | The utm_medium URL parameter of the link used to make the donation.
 utm_source | The utm_source URL parameter of the link used to make the donation.
 utm_term | The utm_term URL parameter of the link used to make the donation.
 utm_content | The utm_content URL parameter of the link used to make the donation.
+phone_number | The wireless phone number of the subscriber.
 refcodes | List of refcode URL parameters of the link used to make the donation.
 
 # Messaging

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1822,7 +1822,7 @@ utm_content | The utm_content URL parameter of the link used to make the donatio
 phone_number | The wireless phone number of the subscriber.
 refcodes | List of refcode URL parameters of the link used to make the donation.
 
-## Creating a New Donation
+## Creating a New Donation for a Subscriber
 
 ```ruby
 require 'net/http'
@@ -1895,15 +1895,15 @@ SUBSCRIBER_ID | ID of the subscriber (phone number)
 
 Parameter | Description
 --------- | -----------
-donation[amount] | The amount of money (in USD) that the subscriber donated - decimal(8,2)
-donation[donated_at] | (optional) The date and time that the donation was made - datetime
-donation[donation_platform] | (optional) The donation platform that the donation was made using - char(191)
-donation[utm_campaign] | (optional) The utm_campaign URL parameter of the link used to make the donation - char(191)
-donation[utm_medium] | (optional) The utm_medium URL parameter of the link used to make the donation - char(191)
-donation[utm_source] | (optional) The utm_source URL parameter of the link used to make the donation - char(191)
-donation[utm_term] | (optional) The utm_term URL parameter of the link used to make the donation - char(191)
-donation[utm_content] | (optional) The utm_content URL parameter of the link used to make the donation - char(191)
-donation[refcodes] | (optional) Array of refcode URL parameters of the link used to make the donation. For example: ["refcode1", "refcode2"]
+amount | The amount of money (in USD) that the subscriber donated - decimal(8,2)
+donated_at | (optional) The date and time that the donation was made - datetime
+donation_platform | (optional) The donation platform that the donation was made using - char(191)
+utm_campaign | (optional) The utm_campaign URL parameter of the link used to make the donation - char(191)
+utm_medium | (optional) The utm_medium URL parameter of the link used to make the donation - char(191)
+utm_source | (optional) The utm_source URL parameter of the link used to make the donation - char(191)
+utm_term | (optional) The utm_term URL parameter of the link used to make the donation - char(191)
+utm_content | (optional) The utm_content URL parameter of the link used to make the donation - char(191)
+refcodes | (optional) Array of refcode URL parameters of the link used to make the donation. For example: ["refcode1", "refcode2"]
 
 ### Responses Explained
 
@@ -1919,6 +1919,102 @@ utm_source | The utm_source URL parameter of the link used to make the donation.
 utm_term | The utm_term URL parameter of the link used to make the donation.
 utm_content | The utm_content URL parameter of the link used to make the donation.
 phone_number | The wireless phone number of the subscriber.
+refcodes | List of refcode URL parameters of the link used to make the donation.
+
+## Creating a New Donation for a Message
+
+```ruby
+require 'net/http'
+require 'uri'
+
+uri = URI.parse('https://app.tatango.com/api/v2/lists/ID/messages/MESSAGE_ID/donations')
+http = Net::HTTP.new(uri.host, uri.port)
+request = Net:HTTP::Post.new(uri.request_url)
+request.basic_auth("emailaddress@mydomain.com", "my_api_key")
+request.body({"amount":"5","donated_at":"2016-09-07T14:10:53-07:00","donation_platform":"AMCE Donations","utm_campaign":"campaign", "utm_medium":"medium","utm_source":"source", "utm_term":"term","utm_content":"content", "refcodes":["refcode1", "refcode2"]});
+response = http.request(request)
+```
+
+```shell
+curl "https://app.tatango.com/api/v2/lists/ID/messages/MESSAGE_ID/donations" -d '{"amount":"5","donated_at":"2016-09-07T14:10:53-07:00","donation_platform":"AMCE Donations","utm_campaign":"campaign", "utm_medium":"medium","utm_source":"source", "utm_term":"term","utm_content":"content", "refcodes":["refcode1", "refcode2"]}' -X POST \
+	-H "Accept: application/json" \
+	-H "Content-Type: application/json" \
+	-u emailaddress@mydomain.com:my_api_key \
+	-H "Host: example.org" \
+	-H "Cookie: "
+```
+
+```javascript
+var request = new XMLHttpRequest();
+request.open("POST", "https://app.tatango.com/api/v2/lists/ID/messages/MESSAGE_ID/donations", false);
+request.setRequestHeader("Authorization", "Basic " + btoa("emailaddress@mydomain.com:my_api_key"));
+var data = JSON.stringify({"amount":"5","donated_at":"2016-09-07T14:10:53-07:00","donation_platform":"AMCE Donations","utm_campaign":"campaign", "utm_medium":"medium","utm_source":"source", "utm_term":"term","utm_content":"content", "refcodes":["refcode1", "refcode2"]});
+request.send(data);
+```
+
+> The above command returns possible JSON responses structured like this:
+
+```json
+{
+   "status":"Donation created",
+   "donation":{
+      "id":1,
+      "amount": "5.0",
+      "donated_at": "2016-09-07T14:10:53.000-07:00",
+      "donation_platform": "AMCE Donations",
+      "utm_campaign": "campaign",
+      "utm_medium": "medium",
+      "utm_source": "source",
+      "utm_term": "term",
+      "utm_content": "content",
+      "refcodes":[
+        "refcode1",
+        "refcode2"
+      ]
+   }
+}
+```
+
+This endpoint adds a donation to a message.
+
+### HTTP Request
+
+`POST https://app.tatango.com/api/v2/lists/ID/messages/MESSAGE_ID/donations`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | ID of the list
+MESSAGE_ID | ID of the message
+
+
+### JSON Parameters (JSON Object)
+Parameter | Description
+--------- | -----------
+amount | The amount of money (in USD) that was donated - decimal(8,2)
+donated_at | (optional) The date and time that the donation was made - datetime
+donation_platform | (optional) The donation platform that the donation was made using - char(191)
+utm_campaign | (optional) The utm_campaign URL parameter of the link used to make the donation - char(191)
+utm_medium | (optional) The utm_medium URL parameter of the link used to make the donation - char(191)
+utm_source | (optional) The utm_source URL parameter of the link used to make the donation - char(191)
+utm_term | (optional) The utm_term URL parameter of the link used to make the donation - char(191)
+utm_content | (optional) The utm_content URL parameter of the link used to make the donation - char(191)
+refcodes | (optional) Array of refcode URL parameters of the link used to make the donation. For example: ["refcode1", "refcode2"]
+
+### Responses Explained
+
+Key | Description
+--------- | -----------
+id | The ID of the donation.
+amount | The amount of money (in USD) that was donated.
+donated_at | The date and time that the donation was made.
+donated_platform | The donation platform that the donation was made using.
+utm_campaign | The utm_campaign URL parameter of the link used to make the donation.
+utm_medium | The utm_medium URL parameter of the link used to make the donation.
+utm_source | The utm_source URL parameter of the link used to make the donation.
+utm_term | The utm_term URL parameter of the link used to make the donation.
+utm_content | The utm_content URL parameter of the link used to make the donation.
 refcodes | List of refcode URL parameters of the link used to make the donation.
 
 # Messaging

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1804,7 +1804,7 @@ This endpoint returns all the donations that a subscriber has made.
 Parameter | Description
 --------- | -----------
 ID | ID of the list
-SUBSCRIBER_ID | ID of the subscriber
+SUBSCRIBER_ID | ID of the subscriber (phone number)
 
 ### Responses Explained
 
@@ -1888,7 +1888,7 @@ This endpoint adds a donation to a subscriber.
 Parameter | Description
 --------- | -----------
 ID | ID of the list
-SUBSCRIBER_ID | ID of the subscriber
+SUBSCRIBER_ID | ID of the subscriber (phone number)
 
 
 ### JSON Parameters (JSON Object)

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1901,9 +1901,9 @@ SUBSCRIBER_ID | ID of the subscriber (phone number)
 Parameter | Description
 --------- | -----------
 amount | The amount of money (in USD) that the subscriber donated - decimal(8,2)
+donation_platform | The donation platform that the donation was made using - char(191)
 donation_platform_uid | A unique id for the donation - char(191)
 donated_at | (optional) The date and time that the donation was made - datetime
-donation_platform | (optional) The donation platform that the donation was made using - char(191)
 utm_campaign | (optional) The utm_campaign URL parameter of the link used to make the donation - char(191)
 utm_medium | (optional) The utm_medium URL parameter of the link used to make the donation - char(191)
 utm_source | (optional) The utm_source URL parameter of the link used to make the donation - char(191)
@@ -2002,9 +2002,9 @@ MESSAGE_ID | ID of the message
 Parameter | Description
 --------- | -----------
 amount | The amount of money (in USD) that the subscriber donated - decimal(8,2)
+donation_platform | The donation platform that the donation was made using - char(191)
 donation_platform_uid | A unique id for the donation - char(191)
 donated_at | (optional) The date and time that the donation was made - datetime
-donation_platform | (optional) The donation platform that the donation was made using - char(191)
 utm_campaign | (optional) The utm_campaign URL parameter of the link used to make the donation - char(191)
 utm_medium | (optional) The utm_medium URL parameter of the link used to make the donation - char(191)
 utm_source | (optional) The utm_source URL parameter of the link used to make the donation - char(191)

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1657,6 +1657,270 @@ Parameter | Description
 --------- | -----------
 ID | ID of the list
 
+# Donations
+
+## Retrieve All Donations in a List
+
+```ruby
+require 'net/http'
+require 'uri'
+
+uri = URI.parse('https://app.tatango.com/api/v2/lists/ID/donations')
+http = Net::HTTP.new(uri.host, uri.port)
+request = Net:HTTP::Get.new(uri.request_url)
+request.basic_auth("emailaddress@mydomain.com", "my_api_key")
+response = http.request(request)
+```
+
+```shell
+curl "https://app.tatango.com/api/v2/lists/ID/donations" -d '' -X GET \
+	-H "Accept: application/json" \
+	-H "Content-Type: application/json" \
+	-u emailaddress@mydomain.com:my_api_key \
+	-H "Host: example.org" \
+	-H "Cookie: "
+```
+
+```javascript
+var request = new XMLHttpRequest();
+request.open("GET", "https://app.tatango.com/api/v2/lists/ID/donations", false);
+request.setRequestHeader("Authorization", "Basic " + btoa("emailaddress@mydomain.com:my_api_key"));
+request.send(null);
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+   "status":"OK",
+   "donation":{
+       "id":1,
+       "amount": "5.0",
+       "donated_at": "2016-09-07T14:10:53.000-07:00",
+       "donation_platform": "AMCE Donations",
+       "utm_campaign": "campaign",
+       "utm_medium": "medium",
+       "utm_source": "source",
+       "utm_term": "term",
+       "utm_content": "content",
+       "phone_number":"2141234567",
+       "refcodes":[
+        "refcode1",
+        "refcode2"
+       ]
+   }
+}
+```
+
+This endpoint returns all the donations made by subscribers in a list.
+
+### HTTP Request
+
+`GET https://app.tatango.com/api/v2/lists/ID/donations`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | ID of the list
+
+### Responses Explained
+
+Key | Description
+--------- | -----------
+id | The ID of the donation.
+amount | The amount of money (in USD) that the subscriber donated.
+donated_at | The date and time that the donation was made.
+donated_platform | The donation platform that the donation was made using.
+utm_campaign | The utm_campaign URL parameter of the link used to make the donation.
+utm_medium | The utm_medium URL parameter of the link used to make the donation.
+utm_source | The utm_source URL parameter of the link used to make the donation.
+utm_term | The utm_term URL parameter of the link used to make the donation.
+utm_content | The utm_content URL parameter of the link used to make the donation.
+phone_number | The wireless phone number of the subscriber.
+refcodes | List of refcode URL parameters of the link used to make the donation.
+
+## Retrieve All Donations from a Subscriber
+
+```ruby
+require 'net/http'
+require 'uri'
+
+uri = URI.parse('https://app.tatango.com/api/v2/lists/ID/subscribers/SUBSCRIBER_ID/donations')
+http = Net::HTTP.new(uri.host, uri.port)
+request = Net:HTTP::Get.new(uri.request_url)
+request.basic_auth("emailaddress@mydomain.com", "my_api_key")
+response = http.request(request)
+```
+
+```shell
+curl "https://app.tatango.com/api/v2/lists/ID/subscribers/SUBSCRIBER_ID/donations" -d '' -X GET \
+	-H "Accept: application/json" \
+	-H "Content-Type: application/json" \
+	-u emailaddress@mydomain.com:my_api_key \
+	-H "Host: example.org" \
+	-H "Cookie: "
+```
+
+```javascript
+var request = new XMLHttpRequest();
+request.open("GET", "https://app.tatango.com/api/v2/lists/ID/subscribers/SUBSCRIBER_ID/donations", false);
+request.setRequestHeader("Authorization", "Basic " + btoa("emailaddress@mydomain.com:my_api_key"));
+request.send(null);
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+   "status":"OK",
+   "donation":{
+       "id":1,
+       "amount": "5.0",
+       "donated_at": "2016-09-07T14:10:53.000-07:00",
+       "donation_platform": "AMCE Donations",
+       "utm_campaign": "campaign",
+       "utm_medium": "medium",
+       "utm_source": "source",
+       "utm_term": "term",
+       "utm_content": "content",
+       "phone_number":"2141234567",
+       "refcodes":[
+        "refcode1",
+        "refcode2"
+       ]
+   }
+}
+```
+
+This endpoint returns all the donations that a subscriber has made.
+
+### HTTP Request
+
+`GET https://app.tatango.com/api/v2/lists/ID/subscribers/SUBSCRIBER_ID/donations`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | ID of the list
+SUBSCRIBER_ID | ID of the subscriber
+
+### Responses Explained
+
+Key | Description
+--------- | -----------
+id | The ID of the donation.
+amount | The amount of money (in USD) that the subscriber donated.
+donated_at | The date and time that the donation was made.
+donated_platform | The donation platform that the donation was made using.
+utm_campaign | The utm_campaign URL parameter of the link used to make the donation.
+utm_medium | The utm_medium URL parameter of the link used to make the donation.
+utm_source | The utm_source URL parameter of the link used to make the donation.
+utm_term | The utm_term URL parameter of the link used to make the donation.
+utm_content | The utm_content URL parameter of the link used to make the donation.
+phone_number | The wireless phone number of the subscriber.
+refcodes | List of refcode URL parameters of the link used to make the donation.
+
+## Creating a New Donation
+
+```ruby
+require 'net/http'
+require 'uri'
+
+uri = URI.parse('https://app.tatango.com/api/v2/lists/ID/subscribers/SUBSCRIBER_ID/donations')
+http = Net::HTTP.new(uri.host, uri.port)
+request = Net:HTTP::Post.new(uri.request_url)
+request.basic_auth("emailaddress@mydomain.com", "my_api_key")
+request.body({"donation":{"amount":"5","donated_at":"2016-09-07T14:10:53-07:00","donation_platform":"AMCE Donations","utm_campaign":"campaign", "utm_medium":"medium","utm_source":"source", "utm_term":"term","utm_content":"content", "refcodes_attributes":[{"refcode":"refcode1"},{"refcode":"refcode2"}]}});
+response = http.request(request)
+```
+
+```shell
+curl "https://app.tatango.com/api/v2/lists/ID/subscribers/SUBSCRIBER_ID/donations" -d '{"donation":{"amount":"5","donated_at":"2016-09-07T14:10:53-07:00","donation_platform":"AMCE Donations","utm_campaign":"campaign", "utm_medium":"medium","utm_source":"source", "utm_term":"term","utm_content":"content", "refcodes_attributes":[{"refcode":"refcode1"},{"refcode":"refcode2"}]}}' -X POST \
+	-H "Accept: application/json" \
+	-H "Content-Type: application/json" \
+	-u emailaddress@mydomain.com:my_api_key \
+	-H "Host: example.org" \
+	-H "Cookie: "
+```
+
+```javascript
+var request = new XMLHttpRequest();
+request.open("POST", "https://app.tatango.com/api/v2/lists/ID/subscribers/SUBSCRIBER_ID/donations", false);
+request.setRequestHeader("Authorization", "Basic " + btoa("emailaddress@mydomain.com:my_api_key"));
+var data = JSON.stringify({"donation":{"amount":"5","donated_at":"2016-09-07T14:10:53-07:00","donation_platform":"AMCE Donations","utm_campaign":"campaign", "utm_medium":"medium","utm_source":"source", "utm_term":"term","utm_content":"content", "refcodes_attributes":[{"refcode":"refcode1"},{"refcode":"refcode2"}]}});
+request.send(data);
+```
+
+> The above command returns possible JSON responses structured like this:
+
+```json
+{
+   "status":"Donation created",
+   "donation":{
+      "id":1,
+      "amount": "5.0",
+      "donated_at": "2016-09-07T14:10:53.000-07:00",
+      "donation_platform": "AMCE Donations",
+      "utm_campaign": "campaign",
+      "utm_medium": "medium",
+      "utm_source": "source",
+      "utm_term": "term",
+      "utm_content": "content",
+      "phone_number":"2141234567",
+      "refcodes":[
+        "refcode1",
+        "refcode2"
+      ]
+   }
+}
+```
+
+This endpoint adds a donation to a subscriber.
+
+### HTTP Request
+
+`POST https://app.tatango.com/api/v2/lists/ID/subscribers/SUBSCRIBER_ID/donations`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | ID of the list
+SUBSCRIBER_ID | ID of the subscriber
+
+
+### JSON Parameters (JSON Object)
+
+Parameter | Description
+--------- | -----------
+donation[amount] | The amount of money (in USD) that the subscriber donated - decimal(8,2)
+donation[donated_at] | (optional) The date and time that the donation was made - datetime
+donation[donation_platform] | (optional) The donation platform that the donation was made using - char(191)
+donation[utm_campaign] | (optional) The utm_campaign URL parameter of the link used to make the donation - char(191)
+donation[utm_medium] | (optional) The utm_medium URL parameter of the link used to make the donation - char(191)
+donation[utm_source] | (optional) The utm_source URL parameter of the link used to make the donation - char(191)
+donation[utm_term] | (optional) The utm_term URL parameter of the link used to make the donation - char(191)
+donation[utm_content] | (optional) The utm_content URL parameter of the link used to make the donation - char(191)
+donation[refcodes_attributes] | (optional) List of refcode URL parameters of the link used to make the donation. For example: [{"refcode": "refcode1"}, {"refcode": "refcode2"}]
+
+### Responses Explained
+
+Key | Description
+--------- | -----------
+id | The ID of the donation.
+amount | The amount of money (in USD) that the subscriber donated.
+donated_at | The date and time that the donation was made.
+donated_platform | The donation platform that the donation was made using.
+utm_campaign | The utm_campaign URL parameter of the link used to make the donation.
+utm_medium | The utm_medium URL parameter of the link used to make the donation.
+utm_source | The utm_source URL parameter of the link used to make the donation.
+utm_term | The utm_term URL parameter of the link used to make the donation.
+utm_content | The utm_content URL parameter of the link used to make the donation.
+phone_number | The wireless phone number of the subscriber.
+refcodes | List of refcode URL parameters of the link used to make the donation.
+
 # Messaging
 
 The following characters can be used: a-z, A-Z, 0-9 and these special characters: .,:;!?()~=+-_\/@$#&%


### PR DESCRIPTION
# Summary

Jira tickets addressed by this pull request:
- [INTEG-56 — Update API documentation with donation endpoints](https://tatango.atlassian.net/browse/INTEG-56)
- [INTEG-184 — Update the donation payload in the public api documentation](https://tatango.atlassian.net/browse/INTEG-184)

## What this PR does
Adds documentation for the following endpoints:
- `GET https://app.tatango.com/api/v2/lists/<list_ID>/subscribers/<phone_number>/donations` (Get all donations from a single membership)
- `POST https://app.tatango.com/api/v2/lists/<list_ID>/subscribers/<phone_number>/donations` (Add a new donation)
- `GET https://app.tatango.com/api/v2/lists/<list_ID>/donations` (Get all donations from memberships in a list)